### PR TITLE
CSRF protection

### DIFF
--- a/london.hackspace.org.uk/login.php
+++ b/london.hackspace.org.uk/login.php
@@ -8,6 +8,8 @@ if ($user) {
 
 if (isset($_POST['submit'])) {
     try {
+        fRequest::validateCSRFToken($_POST['token']);
+
         $validator = new fValidation();
         $validator->addRequiredFields('password', 'email');
         $validator->addEmailFields('email');
@@ -41,6 +43,7 @@ if (isset($_POST['submit'])) {
 ?>
 <h2>Log In</h2>
 <form method="post">
+    <input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
     <fieldset>
         <table>
             <tr>

--- a/london.hackspace.org.uk/members/edit.php
+++ b/london.hackspace.org.uk/members/edit.php
@@ -10,6 +10,8 @@ if (!isset($user)) {
 
 if (isset($_POST['submit'])) {
     try {
+        fRequest::validateCSRFToken($_POST['token']);
+
         $validator = new fValidation();
         $validator->addRequiredFields('fullname', 'email', 'address');
         $validator->addEmailFields('email');
@@ -42,6 +44,7 @@ if (isset($_POST['submit'])) {
 <p><a href="http://www.legislation.gov.uk/ukpga/2006/46/part/8/chapter/2/crossheading/general">UK law</a> requires us to
 store the full name and address of all our members. If you don't provide these details, you won't be able to get membership privileges.</p>
 <form method="post">
+<input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
 <fieldset>
 <table id="edittable">
 <tr><td><label for="email">Email</label></td><td><input type="text" id="email" name="email" value="<?=$user->getEmail()?>"/></td></tr>

--- a/london.hackspace.org.uk/members/wiki.php
+++ b/london.hackspace.org.uk/members/wiki.php
@@ -12,6 +12,8 @@ if (!$user) {
 if($user->isMember()) {
 	$email = $user->getEmail();
 
+	fRequest::validateCSRFToken($_POST['token']);
+
 	// Make database connection.
 	require $_SERVER['DOCUMENT_ROOT'] . '/../var/mediawiki.php';
 	$db = new fDatabase($type, $database, $username, $password, $host, $port );
@@ -97,6 +99,7 @@ if($user->isMember()) {
 						<td><?php echo $details['linked'] ? 'Yes' : 'No' ?></td>
 						<td>
 							<form method="POST" style="margin: 0;">
+								<input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
 								<input type="hidden" name="wikiuser" value="<?php echo $id ?>">
 								<input type="submit" name="<?php echo $details['linked'] ? 'unlink' : 'link' ?>" value="<?php echo $details['linked'] ? 'Unlink' : 'Link' ?>">
 							</form>
@@ -110,6 +113,7 @@ if($user->isMember()) {
 		<hr>
 		<?php if( isset( $error ) ) echo $error; ?>
 		<form method="POST">
+			<input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
 			<table>
 				<tr>
 					<td><label for="username">Wiki username</label></td>

--- a/london.hackspace.org.uk/signup.php
+++ b/london.hackspace.org.uk/signup.php
@@ -8,6 +8,8 @@ if ($user) {
 
 if (isset($_POST['submit'])) {
     try {
+        fRequest::validateCSRFToken($_POST['token']);
+
         $validator = new fValidation();
         $validator->addRequiredFields('fullname', 'password', 'email', 'address');
         $validator->addEmailFields('email');
@@ -55,6 +57,7 @@ organisation like this in London isn't cheap, so please be as generous as you ca
 you provide your real name and address in order to join.</p>
 
 <form method="post">
+<input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
 <fieldset>
 <table id="signuptable">
 <tr><td><label for="email">Email</label></td><td><input type="text" id="email" name="email"/></td></tr>


### PR DESCRIPTION
Stop a malicious user updating other people's details/accounts.  Also prevents persistent XSS possible by logging in a fake user.

To test: all affected forms (esp. the wiki one)
