### PR TITLE
Member stats script for Cacti

### DIFF
--- a/london.hackspace.org.uk/members/member_stats.php
+++ b/london.hackspace.org.uk/members/member_stats.php
@@ -1,0 +1,6 @@
+<?php
+require_once( $_SERVER['DOCUMENT_ROOT'] . '/../lib/init.php');
+$subscribers = $db->translatedQuery( 'SELECT COUNT(id) AS num FROM users WHERE subscribed=1' )->fetchRow();
+$pending = $db->translatedQuery( 'SELECT COUNT(id) AS num FROM users WHERE subscribed=0' )->fetchRow();
+
+print "subscribed:{$subscribers['num']} pending:{$pending['num']}";


### PR DESCRIPTION
This is the member stats php script that exposes member numbers to Cacti. It is currently deployed on Turing but should be committed into the main git project so that it doesn't go missing.
