### PR TITLE
PHP script to expose average subscription to Cacti

### DIFF
--- a/london.hackspace.org.uk/members/subscription_stats.php
+++ b/london.hackspace.org.uk/members/subscription_stats.php
@@ -1,0 +1,5 @@
+<?php
+require_once( $_SERVER['DOCUMENT_ROOT'] . '/../lib/init.php');
+$average = $db->translatedQuery( 'SELECT AVG(amount) AS num FROM transactions WHERE timestamp >= date("now", "-30 day")' )->fetchRow();
+
+print "averageSubscription:{$average['num']}";


### PR DESCRIPTION
Note: This only exposes the monthly average so hopefully will not be classified as sensitive information.

Calculates 30 day rolling average for the subscription amount. Will be inaccurate if quarterly/yearly/adhoc payments also end up in this table.
