### PR TITLE
Card state improved

### DIFF
--- a/london.hackspace.org.uk/members/cards.php
+++ b/london.hackspace.org.uk/members/cards.php
@@ -71,9 +71,9 @@ if (isset($_POST['update_details'])) {
             <td><?=$card->getUid()?></td>
             <td style="text-align: center">
                 <? if ($card->getActive()): ?>
-                <input type="submit" name="disable_<?=$card->getUid()?>" value="Disable" />
+                <input type="submit" name="disable_<?=$card->getUid()?>" value="Disable" title="This card is currently enabled. Click to disable it." />
                 <? else: ?>
-                <input type="submit" name="enable_<?=$card->getUid()?>" value="Enable" />
+                <input type="submit" name="enable_<?=$card->getUid()?>" value="Enable" title="This card is currently disabled. Click to enable it." />
                 <? endif; ?>
             </td>
         </tr>


### PR DESCRIPTION
This is the simplest way I could think of to improve the card interface. The button now states what it is going to do rather than what state the card is currently in which may be confusing. The state is now implied by the inverse of the message on the button while the button describes what action will happen when you press it.

There is also a description as a title attribute on the button showing the current state of the card and what will happen when the button is pressed.

The only way to make it clearer after this is to add a bit of text either in the same cell or in a new column describing the current state.
