### PR TITLE
Adding LHS community contact details

### DIFF
--- a/london.hackspace.org.uk/organisation/index.php
+++ b/london.hackspace.org.uk/organisation/index.php
@@ -25,7 +25,7 @@ require('../header.php');
 
 <p>There are several ways of getting in contact with London Hackspace members and starting a first conversation, be it that you want to learn more about our community, you are interested in coming to our space, you want to discuss your project with someone, or for any other reason.</p>
 
-<p>We have a number of very active <a href="http://wiki.london.hackspace.org.uk/view/Mailing_List">mailing lists</a> for the community and its subgroups, an <a href="http://wiki.london.hackspace.org.uk/view/IRC">IRC channel</a> on Freenode, but also a weekly <a href="http://wiki.london.hackspace.org.uk/view/Weekly_Open_Evenings">social night on every Tuesday</a> that is open to the public.</p>
+<p>We have a number of very active <a href="http://wiki.london.hackspace.org.uk/view/Mailing_List">mailing lists</a> for the community and its subgroups, an <a href="http://wiki.london.hackspace.org.uk/view/IRC">IRC channel</a> on Freenode, but also a weekly <a href="http://wiki.london.hackspace.org.uk/view/Weekly_Open_Evenings">social night every Tuesday</a> that is open to the public.</p>
 
 <h3>Directors</h3>
 


### PR DESCRIPTION
I'm thinking we should have a prominent contact page on our main site that promotes the mailing list and IRC, atm the shortest path to a contact is trustees@ (homepage -> organisation -> trustees wiki page)
