### PR TITLE
Fixed a nitpick: Flickr grid of images was padded horizontally, but not vertically

### DIFF
--- a/london.hackspace.org.uk/css/main.css
+++ b/london.hackspace.org.uk/css/main.css
@@ -127,13 +127,11 @@ div.home-page-section {
 .flickr-badge-container a {
     width: 78px;
     height: 78px;
-    padding: 2px;
     margin: 0;
 }
 
 .flickr-badge-container a img {
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding: 2px;
 }
 
 #google-maps-content {


### PR DESCRIPTION
On the homepage the square Flickr images in a grid were padded on the left and right, but not on top or bottom driving me mad ;)
