### PR TITLE
Proper card-adding interface

### DIFF
--- a/london.hackspace.org.uk/addcard_form.php
+++ b/london.hackspace.org.uk/addcard_form.php
@@ -1,0 +1,36 @@
+<?
+/*
+ * For a card-adding station, return a page that can be filled in
+ * with the scanned UID, to keep it out of the browser history.
+ */
+
+require_once( $_SERVER['DOCUMENT_ROOT'] . '/../lib/init.php');
+if ($user) {
+    fSession::destroy();
+    fURL::redirect();
+}
+
+$uid = isset($_GET['uid']) ? htmlentities($_GET['uid']) : '{0}';
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Add card redirect</title>
+    <style type="text/css">
+        form {display: none}
+    </style>
+</head>
+<body>
+    <p>Redirecting, please wait...</p>
+    <form name="addcard" action="<?=fURL::getDomain() ?>/login_and_addcard.php" method="post">
+        <label for="uid">Card to add</label>
+        <input type="text" name="uid" value="<?=$uid?>"/>
+        <input type="submit" name="addcard" value="Add"/>
+    </form>
+    <script type="text/javascript">
+        document.forms.addcard.submit();
+    </script>
+</body>
+</html>
+<?

--- a/london.hackspace.org.uk/login_and_addcard.php
+++ b/london.hackspace.org.uk/login_and_addcard.php
@@ -1,0 +1,97 @@
+<?
+$page = 'addcard';
+require('header.php');
+
+if ($user) {
+    fSession::destroy();
+    fURL::redirect();
+}
+
+if (isset($_POST['submit'])) {
+    try {
+        fRequest::validateCSRFToken($_POST['token']);
+
+        $validator = new fValidation();
+        $validator->addRequiredFields('password', 'email', 'uid');
+        $validator->addEmailFields('email');
+        $validator->addRegexRule('uid', '#^[0-9a-zA-Z]+$#', 'Has invalid characters');
+
+        $validator->validate();
+
+        $users = fRecordSet::build('User', array('email=' => strtolower($_POST['email'])));
+        if ($users->count() == 0) {
+            throw new fValidationException('Invalid username or password.');
+        }
+
+        $rec = $users->getRecords();
+        $user = $rec[0];
+
+        if (!fCryptography::checkPasswordHash($_POST['password'], $user->getPassword())) {
+            throw new fValidationException('Invalid username or password.');
+        }
+
+        //fSession::set('user', $user->getId());
+
+        $card = new Card();
+        $card->setUserId($user->getId());
+        $card->setAddedDate(time());
+        $card->setUid($_POST['uid']);
+        $card->store();
+
+        fSession::destroy();
+        fURL::redirect('?added');
+
+        exit;
+    } catch (fValidationException $e) {
+        echo "<p>" . $e->printMessage() . "</p>";
+    } catch (fSQLException $e) {
+        echo "<p>An unexpected error occurred, please try again later</p>";
+        trigger_error($e);
+    }
+}
+
+if (isset($_GET['added']) && !isset($_POST['submit'])) {
+
+?>
+<p>Your card was added. For security, you have been logged out.</p>
+<?
+
+} else {
+
+?>
+<h2>Log In</h2>
+<form method="post">
+    <input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
+    <fieldset>
+        <table>
+            <tr>
+                <td><label for="email">Email</label></td>
+                <td><input type="email" id="email" name="email"/></td>
+            </tr>
+            <tr>
+                <td><label for="password">Password</label></td>
+                <td><input type="password" id="password" name="password" /></td>
+            </tr>
+            <tr>
+                <td><label for="uid">Card to add</label></td>
+                <td>
+                <? if (isset($_POST['uid'])) { ?>
+                    <?=htmlentities($_POST['uid'])?>
+                    <input type="hidden" name="uid" value="<?=htmlentities($_POST['uid'])?>" />
+                <? } else { ?>
+                    <input type="text" name="uid"/>
+                <? } ?>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2"><input type="submit" name="submit" value="Add card" /></td>
+            </tr>
+        </table>
+    </fieldset>
+</form>
+
+<p>Forgotten your password? <a href="passwordreset.php">Reset it here</a>.</p>
+<?
+}
+
+require('footer.php');


### PR DESCRIPTION
For a shared workstation situation, it's best to keep the card ID out of the URL, while a kiosk doesn't matter so much. I've added a page (addcard_form.php) that allows both methods, and dedicated login page for adding cards.

This will replace members/addcard.php (fixing #34) and is a prerequisite of londonhackspace/Doorbot#4.
