### PR TITLE
Added instructions on where to find the packgate padlock code

### DIFF
--- a/emails/subscribe.erb
+++ b/emails/subscribe.erb
@@ -15,7 +15,8 @@ http://wiki.london.hackspace.org.uk/view/Mailing_List
 
 To get 24-hour access, you'll need to register your Oyster card (or other
 similar RFID card). The easiest way to do this is to visit the space and ask a
-friendly member to help you add your card.
+friendly member to help you add your card. The code for the back gate padlock 
+can be found in the members section at https://london.hackspace.org.uk/members/code.php
 
 Thanks,
 


### PR DESCRIPTION
Added a link to the "code access" page to help people that have trouble reading our wiki as per: 
https://groups.google.com/forum/#!topic/london-hack-space/YqWxuqx2Ph4
