### PR TITLE
Uppercase UID before inserting into DB

### DIFF
--- a/london.hackspace.org.uk/login_and_addcard.php
+++ b/london.hackspace.org.uk/login_and_addcard.php
@@ -18,7 +18,8 @@ if (isset($_POST['submit'])) {
 
         $validator->validate();
 
-        if ($_POST['uid'] == '21222324') {
+        $uid = strtoupper($_POST['uid']);
+        if ($uid == '21222324') {
             /* New Visa cards return this, presumably for privacy */
             throw new fValidationException('Non-unique UID.');
         }
@@ -40,7 +41,7 @@ if (isset($_POST['submit'])) {
         $card = new Card();
         $card->setUserId($user->getId());
         $card->setAddedDate(time());
-        $card->setUid($_POST['uid']);
+        $card->setUid($uid);
         $card->store();
 
         fSession::destroy();

--- a/london.hackspace.org.uk/members/addcard.php
+++ b/london.hackspace.org.uk/members/addcard.php
@@ -18,7 +18,8 @@ if (isset($_POST['submit'])) {
 
         $validator->validate();
 
-        if ($_POST['uid'] == '21222324') {
+        $uid = strtoupper($_POST['uid']);
+        if ($uid == '21222324') {
             /* New Visa cards return this, presumably for privacy */
             throw new fValidationException('Non-unique UID.');
         }
@@ -26,7 +27,7 @@ if (isset($_POST['submit'])) {
         $card = new Card();
         $card->setUserId($user->getId());
         $card->setAddedDate(time());
-        $card->setUid($_POST['uid']);
+        $card->setUid($uid);
         $card->store();
         fURL::redirect('/members/cards.php');
         exit;


### PR DESCRIPTION
After pulling this change in, could you run the following SQL to sanitise the data?

```
create table invalid_cards as select * from cards where uid != upper(uid);
delete from cards where uid in (select uid from invalid_cards);
select count(*) from cards where uid != upper(uid); -- should be 0
```

(lowercase cards won't be working atm anyway, so nobody's losing out here)
