### PR TITLE
Strip colons from submitted card uids

### DIFF
--- a/london.hackspace.org.uk/login_and_addcard.php
+++ b/london.hackspace.org.uk/login_and_addcard.php
@@ -11,6 +11,10 @@ if (isset($_POST['submit'])) {
     try {
         fRequest::validateCSRFToken($_POST['token']);
 
+        // Strip colons from uid (easier to copy paste from some NFC
+        // reader apps).
+        fRequest::set('uid', str_replace(':','',fRequest::get('uid')) );
+
         $validator = new fValidation();
         $validator->addRequiredFields('password', 'email', 'uid');
         $validator->addEmailFields('email');


### PR DESCRIPTION
Some mobile apps give you your card uid with colons separating hex digit pairs. Strip these out before checking shit.