### PR TITLE
Autoload flourish classes using spl_autoload instead

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -1,16 +1,18 @@
 <?php
 
-function __autoload($class_name)
+function load_flourish_classes($class_name)
 {
+
     // Customize this to your root Flourish directory
     $flourish_root = $_SERVER['DOCUMENT_ROOT'] . '/../lib/flourish/';
-    
+
     $file = $flourish_root . $class_name . '.php';
- 
+
     if (file_exists($file)) {
         require_once($file);
         return;
     }
-    
-    throw new Exception('The class ' . $class_name . ' could not be loaded');
+
 }
+
+spl_autoload_register('load_flourish_classes');


### PR DESCRIPTION
It is now "highly recommended" that you use spl_autoload_register instead of __autoload.
