### PR TITLE
Clarify text on tools.php

### DIFF
--- a/london.hackspace.org.uk/members/tools.php
+++ b/london.hackspace.org.uk/members/tools.php
@@ -54,7 +54,7 @@ ensureMember();
             <th>Tool</th>
             <th>Status<small>Status and availability</small></th>
             <th>Status message <small>Any extra info</small></th>
-            <th>Access? <small>Access level, if any</small></th>
+            <th>Access? <small>Your access level</small></th>
             
           </tr>
         </thead>


### PR DESCRIPTION
The text refers to the access level of the user looking at this page, not the access level of the tool, or the user currently actually using the tool.