### PR TITLE
Update members page payment history

### DIFF
--- a/london.hackspace.org.uk/members/index.php
+++ b/london.hackspace.org.uk/members/index.php
@@ -19,26 +19,6 @@ if (!$user) {
     <p>You're currently a member of London Hackspace, thanks for your support!</p>
     <h3>Reference Number</h3>
     <p>Your standing order reference number is: <strong><?=$user->getMemberNumber()?></strong></p>
-
-<h3>Your Recent Payments</h3>
-<table class="table">
-    <thead>
-    <tr>
-        <th>Date</th>
-        <th>Amount</th>
-    </tr>
-    </thead>
-    <tbody>
-    <? foreach($user->buildTransactions() as $transaction) {?>
-    <tr>
-        <td><?=$transaction->getTimestamp()?></td>
-        <td>£<?=$transaction->getAmount()?></td>
-    </tr>
-    <? } ?>
-    </tbody>
-</table>
-
-
 <? } else { ?>
     <p>You're not currently a member of London Hackspace. To become a member, we ask that you pay what you
        think the space is worth to you. Running a place like this isn't cheap, so please be as
@@ -96,6 +76,24 @@ if (!$user) {
       <a href="mailto:membership@london.hackspace.org.uk">membership@london.hackspace.org.uk</a>.</p>
 
 <? } ?>
+
+<h3>Your Recent Payments</h3>
+<table class="table">
+    <thead>
+    <tr>
+        <th>Date</th>
+        <th>Amount</th>
+    </tr>
+    </thead>
+    <tbody>
+    <? foreach($user->buildTransactions() as $transaction) {?>
+    <tr>
+        <td><?=$transaction->getTimestamp()?></td>
+        <td>£<?=$transaction->getAmount()?></td>
+    </tr>
+    <? } ?>
+    </tbody>
+</table>
 
 <? require('../footer.php'); ?>
 </body>


### PR DESCRIPTION
I've moved the payment history table to show regardless of whether a user is or is not currently a member. As someone who was previously a member I'd like to see what I paid, even if I am no longer a member (and am unlikely to be in the future).