### PR TITLE
Stop kiosk from giving out emails

### DIFF
--- a/london.hackspace.org.uk/kiosk/addcard.php
+++ b/london.hackspace.org.uk/kiosk/addcard.php
@@ -50,7 +50,7 @@ Please allow at least 5 minutes before attempting to use that card on door entry
     <input type="hidden" name="token" value="<?=fRequest::generateCSRFToken()?>" />
     <div class="form-group">
         <label for="email">Email</label>
-        <input class="form-control" type="email" id="email" name="email">
+        <input class="form-control" type="email" id="email" name="email" autocomplete="dont-give-out-emails">
     </div>
     <div class="form-group">
         <label for="password">Password</label>


### PR DESCRIPTION
It was noted the other day that the kiosk is displaying a list of other user's email addresses in as autocomplete options in the add card page.

The strange property value is due to chromium's interesting autocomplete handling ( see https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164 for more details).