### PR TITLE
handle forwarding on instances with non-standard ports

### DIFF
--- a/london.hackspace.org.uk/login.php
+++ b/london.hackspace.org.uk/login.php
@@ -37,7 +37,11 @@ if (isset($_POST['submit'])) {
         }
 
         if (isset($_POST['forward'])) {
-            fURL::redirect('http://' . $_SERVER['SERVER_NAME'] . $_POST['forward']);
+            if(substr($_POST['forward'],0,1)=='/'){
+              fURL::redirect($_POST['forward']);
+            } else {
+              throw new fValidationException('Forward should be an absolute path in the current site');
+            }
         } else {
             fURL::redirect('/members');
         }


### PR DESCRIPTION
The existing code assumes that the "forward" parameter is an absolute path of the form "/members/cards.php", however it assumed a protocol standard port which doesn't work if running under docker-compose on another port.

This change validates that the forward path is plausibly a absolute path in the current site, and redirects to that, implicity using the existing servername, port and scheme.