### PR TITLE
hide links to /members/webcams.php and /members/tools.php as they seems to break site

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       - POSTGRES_DB=hackspace
       - POSTGRES_USER=hackspace
       - POSTGRES_PASSWORD=hackspace
+    ports:
+      - 5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,6 @@ services:
       - POSTGRES_DB=hackspace
       - POSTGRES_USER=hackspace
       - POSTGRES_PASSWORD=hackspace
-    ports:
-      - 5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:

--- a/london.hackspace.org.uk/menu.php
+++ b/london.hackspace.org.uk/menu.php
@@ -14,6 +14,7 @@
             <?=menulink('/donate.php', 'donate', 'Donate')?>
             <?if (isset($user) && $user->isMember()) {?>
                 <?=menulink('/members/members.php', 'memberslist', 'Members List')?>
+                <!-- <?=menulink('/members/webcams.php', 'webcams', 'Webcams')?> -->
                 <?=menulink('/storage/list.php', 'storagelist', 'Storage Requests')?>
                 <?=menulink('/members/minutes.php', 'minutes', 'Minutes')?>
             <? } ?>
@@ -25,7 +26,7 @@
                         <?=menulink('/members/cards.php', 'cards', 'Access Cards')?>
                         <?if (isset($user) && $user->isMember()) {?>
                         <?=menulink('/members/code.php', 'code', 'Car Park Code')?>
-                        <?=menulink('/members/tools.php', 'tools', 'Tools')?>
+                        <!-- <?=menulink('/members/tools.php', 'tools', 'Tools')?> -->
                         <?=menulink('/members/ldap.php', 'LDAP', 'Edit LDAP Account')?>
                         <? } ?>
                     </ul>

--- a/london.hackspace.org.uk/menu.php
+++ b/london.hackspace.org.uk/menu.php
@@ -14,7 +14,6 @@
             <?=menulink('/donate.php', 'donate', 'Donate')?>
             <?if (isset($user) && $user->isMember()) {?>
                 <?=menulink('/members/members.php', 'memberslist', 'Members List')?>
-                <?=menulink('/members/webcams.php', 'webcams', 'Webcams')?>
                 <?=menulink('/storage/list.php', 'storagelist', 'Storage Requests')?>
                 <?=menulink('/members/minutes.php', 'minutes', 'Minutes')?>
             <? } ?>


### PR DESCRIPTION
## These links 

- /members/webcams.php
- /members/tools.php

make calls to backends that don't exist or are not accessible at the moment. 

These aren't accessible from the site:

- http://acserver.london.hackspace.org.uk:1234
- zoneminder.lan.london.hackspace.org.uk

## What does this PR change

This PR hides those links from the menus

## Tests

I tested this with the local docker-compose

![2023-09-15_23-34](https://github.com/londonhackspace/hackspace-foundation-sites/assets/91288/7467632e-4c7c-4792-8ef1-063550aa06ef)

menu items are hidden. This is work around

![2023-09-15_23-35](https://github.com/londonhackspace/hackspace-foundation-sites/assets/91288/19ec6bb1-7782-4171-8ae2-63480e990fea)


